### PR TITLE
Ban on an address is removed before authenticationFailureBanTime passed

### DIFF
--- a/Internal.h
+++ b/Internal.h
@@ -167,6 +167,7 @@ typedef	enum {
   @private
     NSTimeInterval       _findTime;
     NSMutableDictionary  *_failuresByAddress;
+    NSMutableDictionary  *_banUntilByAddress;
     NSLock               *_lock;
     NSTimeInterval       _cleanupInterval;
     NSTimer              *_cleanupTimer;
@@ -180,6 +181,9 @@ typedef	enum {
 - (void) removeFailuresForAddress: (NSString*)address;
 - (NSUInteger) failureCountForAddress: (NSString*)address
                            blockUntil: (NSDate**)until;
+- (void) banAddress: (NSString*)address
+              until: (NSDate*)until;
+- (NSDate*) isBanned: (NSString*)address;
 @end
 
 @interface	WebServerConnection : GSListLink

--- a/Tests/testBlockOnAuthenticationFailure.m
+++ b/Tests/testBlockOnAuthenticationFailure.m
@@ -316,6 +316,27 @@ main()
 
   END_SET("Block on custom authentication failure")
 
+  // wait for the authentication failure log to be cleaned up
+  wait(FIND_TIME);
+
+  START_SET("Disable block on authentication failure")
+
+  // disable block on authentication failure
+  [server setAuthenticationFailureBanTime: 0.0];
+
+  // make MAX_RETRY + 1 invalid password attempts
+  for (int i = 0; i <= MAX_RETRY; i++) 
+    {
+      response = post(@"user", @"ValidPassword", @{@"key": @"InvalidKey"});
+      PASS([response statusCode] == 401, "Response is 401");
+    }
+
+  // check that we are still not banned
+  response = post(@"user", @"ValidPassword", @{@"key": @"ValidKey"});
+  PASS([response statusCode] == 200, "Response is 200");
+  
+  END_SET("Disable block on authentication failure")
+
   RELEASE(authFailureLog);
   RELEASE(handler);
   RELEASE(handlerWithAuth);

--- a/WebServer.m
+++ b/WebServer.m
@@ -3450,9 +3450,8 @@ escapeData(const uint8_t *bytes, NSUInteger length, NSMutableData *d)
   [_lock lock];
 
   addresses = [_failuresByAddress allKeys];
-  for (NSInteger i = [addresses count] - 1; i >= 0; i--)
+  for (address in addresses)
     {
-      address = [addresses objectAtIndex: i];
       failures = [_failuresByAddress objectForKey: address];
       for (NSInteger j = [failures count] - 1; j >= 0; j--)
         {
@@ -3469,9 +3468,8 @@ escapeData(const uint8_t *bytes, NSUInteger length, NSMutableData *d)
     }
 
   addresses = [_banUntilByAddress allKeys];
-  for (NSInteger i = [addresses count] - 1; i >= 0; i--)
+  for (address in addresses)
     {
-      address = [addresses objectAtIndex: i];
       until = [_banUntilByAddress objectForKey: address];
       if ([until compare: [NSDate date]] == NSOrderedAscending)
         {

--- a/WebServer.m
+++ b/WebServer.m
@@ -1650,13 +1650,13 @@ escapeData(const uint8_t *bytes, NSUInteger length, NSMutableData *d)
     }
   else
     {
-      _authFailureBanTime = 1.0;
+      _authFailureBanTime = 0.0;
     }
 }
 
 - (void) setAuthenticationFailureMaxRetry: (NSUInteger)max
 {
-  if (max >= 0)
+  if (max > 0)
     {
       _authFailureMaxRetry = max;
     }
@@ -2255,6 +2255,11 @@ escapeData(const uint8_t *bytes, NSUInteger length, NSMutableData *d)
 
 - (void) _blockAddress: (NSString*)address forInterval: (NSTimeInterval)ti
 {
+  if (_authFailureBanTime <= 0.0)
+    {
+      return;
+    }
+
   if (nil == _authFailureLog)
     {
       _authFailureLog = [WebServerAuthenticationFailureLog new];
@@ -2283,6 +2288,11 @@ escapeData(const uint8_t *bytes, NSUInteger length, NSMutableData *d)
 {
   NSDate        *until;
   NSUInteger    count;
+
+  if (_authFailureBanTime <= 0.0)
+    {
+      return nil;
+    }
 
   if (nil != (until = [_authFailureLog isBanned: address]))
     {


### PR DESCRIPTION
While doing some testing I have noticed that the ban on an address was removed before authenticationFailureBanTime passed. The issue was that the code was always looking at the number of failures in the time window to decide if an address was banned or not. However once an address is banned because it went over the authentication failure limits it should stays banned (irrespectively of the number recent failures).
This new implementation keeps track of banned addresses in a separate dictionary.  I have modified the test case to cover this scenario. 

Another issue was that disabling the block authentication mechanism (by setting authenticationFailureBanTime to 0.0) was not working. Fixed the bug and added test case. 